### PR TITLE
Fix superflat settings not being applied for 1.21-1.21.2

### DIFF
--- a/src/main/java/de/melanx/defaultworldtype/mixin/WorldCreationUiStateMixin.java
+++ b/src/main/java/de/melanx/defaultworldtype/mixin/WorldCreationUiStateMixin.java
@@ -2,12 +2,22 @@ package de.melanx.defaultworldtype.mixin;
 
 import de.melanx.defaultworldtype.ClientConfig;
 import de.melanx.defaultworldtype.DefaultWorldType;
+import net.minecraft.client.gui.screens.PresetFlatWorldScreen;
+import net.minecraft.client.gui.screens.worldselection.WorldCreationContext;
 import net.minecraft.client.gui.screens.worldselection.WorldCreationUiState;
+import net.minecraft.core.HolderGetter;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.levelgen.FlatLevelSource;
+import net.minecraft.world.level.levelgen.flat.FlatLevelGeneratorSettings;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import net.minecraft.world.level.levelgen.presets.WorldPreset;
+import net.minecraft.world.level.levelgen.presets.WorldPresets;
+import net.minecraft.world.level.levelgen.structure.StructureSet;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -42,6 +52,9 @@ public abstract class WorldCreationUiStateMixin {
         }
 
         WorldCreationUiStateMixin.defaultWorldType$selectInitialWorldType(state);
+        if (ClientConfig.getKey() == WorldPresets.FLAT) {
+            defaultWorldType$setFlatSettings(state);
+        }
     }
 
     @Unique
@@ -89,6 +102,21 @@ public abstract class WorldCreationUiStateMixin {
                 .orElse(state.normalPresetList.getFirst());
 
         state.setWorldType(entry);
+    }
+
+    @Unique
+    private static void defaultWorldType$setFlatSettings(WorldCreationUiState state) {
+        state.updateDimensions((registry, worldDimensions) -> {
+            WorldCreationContext settings = state.getSettings();
+
+            HolderGetter<Block> block = settings.worldgenLoadContext().lookupOrThrow(Registries.BLOCK);
+            HolderGetter<Biome> biome = settings.worldgenLoadContext().lookupOrThrow(Registries.BIOME);
+            HolderGetter<StructureSet> structureSet = settings.worldgenLoadContext().lookupOrThrow(Registries.STRUCTURE_SET);
+            HolderGetter<PlacedFeature> placedFeature = settings.worldgenLoadContext().lookupOrThrow(Registries.PLACED_FEATURE);
+            FlatLevelSource flatLevelSource = new FlatLevelSource(PresetFlatWorldScreen.fromString(block, biome, structureSet, placedFeature, ClientConfig.flatMapSettings.get(), FlatLevelGeneratorSettings.getDefault(biome, structureSet, placedFeature)));
+
+            return worldDimensions.replaceOverworldGenerator(registry, flatLevelSource);
+        });
     }
 
 }


### PR DESCRIPTION
Basically identical to @MelanX's commit for the newer versions, but for 1.21-1.21.2. I mainly just typed it out to make sure there weren't any different/missing classes, and I tested it to make sure it worked. I'm more of a fabric coder honestly, so the small chance I missed something isn't completely off the table.